### PR TITLE
Change topograatone url to use capital G

### DIFF
--- a/src/config/map/baseMap.js
+++ b/src/config/map/baseMap.js
@@ -1,6 +1,6 @@
 const baseMap = {
    wmtsUrl: 'https://cache.kartverket.no/v1/wmts/1.0.0/WMTSCapabilities.xml',
-   layer: 'topograatone',
+   layer: 'topoGraatone',
    extent: [383929.977677947, 7874328.561786267, 3598402.535883406, 11548011.485449649],
    minZoom: 5,
    maxZoom: 18


### PR DESCRIPTION
TNT changed the layername to use capital G. This PR changes the layername to the new one so the backgroundmap get shown again. 

Might need to revert the name back in the future if the new name is reverted.
